### PR TITLE
Cleanup unused imports

### DIFF
--- a/addon/helpers/and.js
+++ b/addon/helpers/and.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import truthConvert from '../utils/truth-convert';
 
 export function andHelper(params) {

--- a/addon/helpers/equal.js
+++ b/addon/helpers/equal.js
@@ -1,5 +1,3 @@
-import Ember from 'ember';
-
 export function equalHelper(params) {
   return params[0] === params[1];
 }

--- a/addon/helpers/not.js
+++ b/addon/helpers/not.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import truthConvert from '../utils/truth-convert';
 
 export function notHelper(params) {

--- a/addon/helpers/or.js
+++ b/addon/helpers/or.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import truthConvert from '../utils/truth-convert';
 
 export function orHelper(params) {

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -70,5 +70,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true
+  "esnext": true,
+  "unused": true
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import Application from '../../app';
-import Router from '../../router';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {


### PR DESCRIPTION
This removes unused imports from several files. They can cause test failures when applications are running their tests with jshint's `{unused: true}`.