### PR TITLE
Expose helpers under app/helpers/ directory to allow auto-registering them in 1.13

### DIFF
--- a/app/helpers/and.js
+++ b/app/helpers/and.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import { andHelper } from 'ember-truth-helpers/helpers/and';
+
+export default Ember.Helper.helper(andHelper);

--- a/app/helpers/eq.js
+++ b/app/helpers/eq.js
@@ -1,4 +1,4 @@
 import Ember from 'ember';
-import { equalHelper } from 'ember-truth-helpers/helpers/eq';
+import { equalHelper } from 'ember-truth-helpers/helpers/equal';
 
 export default Ember.Helper.helper(equalHelper);

--- a/app/helpers/eq.js
+++ b/app/helpers/eq.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import { equalHelper } from 'ember-truth-helpers/helpers/eq';
+
+export default Ember.Helper.helper(equalHelper);

--- a/app/helpers/gt.js
+++ b/app/helpers/gt.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import { gtHelper } from 'ember-truth-helpers/helpers/gt';
+
+export default Ember.Helper.helper(gtHelper);

--- a/app/helpers/gte.js
+++ b/app/helpers/gte.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import { gteHelper } from 'ember-truth-helpers/helpers/gte';
+
+export default Ember.Helper.helper(gteHelper);

--- a/app/helpers/is-array.js
+++ b/app/helpers/is-array.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import { isArrayHelper } from 'ember-truth-helpers/helpers/is-array';
+
+export default Ember.Helper.helper(isArrayHelper);

--- a/app/helpers/lt.js
+++ b/app/helpers/lt.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import { ltHelper } from 'ember-truth-helpers/helpers/lt';
+
+export default Ember.Helper.helper(ltHelper);

--- a/app/helpers/lte.js
+++ b/app/helpers/lte.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import { lteHelper } from 'ember-truth-helpers/helpers/lte';
+
+export default Ember.Helper.helper(lteHelper);

--- a/app/helpers/not-eq.js
+++ b/app/helpers/not-eq.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import { notEqualHelper } from 'ember-truth-helpers/helpers/not-eq';
+
+export default Ember.Helper.helper(notEqualHelper);

--- a/app/helpers/not-eq.js
+++ b/app/helpers/not-eq.js
@@ -1,4 +1,4 @@
 import Ember from 'ember';
-import { notEqualHelper } from 'ember-truth-helpers/helpers/not-eq';
+import { notEqualHelper } from 'ember-truth-helpers/helpers/not-equal';
 
 export default Ember.Helper.helper(notEqualHelper);

--- a/app/helpers/not.js
+++ b/app/helpers/not.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import { notHelper } from 'ember-truth-helpers/helpers/not';
+
+export default Ember.Helper.helper(notHelper);

--- a/app/helpers/or.js
+++ b/app/helpers/or.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import { orHelper } from 'ember-truth-helpers/helpers/or';
+
+export default Ember.Helper.helper(orHelper);

--- a/app/initializers/truth-helpers.js
+++ b/app/initializers/truth-helpers.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { registerHelper } from 'ember-truth-helpers/utils/register-helper';
 
 import { andHelper } from 'ember-truth-helpers/helpers/and';
@@ -12,6 +13,13 @@ import { ltHelper } from 'ember-truth-helpers/helpers/lt';
 import { lteHelper } from 'ember-truth-helpers/helpers/lte';
 
 export function initialize(/* container, application */) {
+
+  // Do not register helpers from Ember 1.13 onwards, starting from 1.13 they
+  // will be auto-discovered.
+  if (Ember.Helper) {
+    return;
+  }
+
   registerHelper('and', andHelper);
   registerHelper('or', orHelper);
   registerHelper('eq', equalHelper);


### PR DESCRIPTION
Starting from ember 1.13.0 those helpers would be auto-registered and usable inside new component integration tests