### PR TITLE
weak-equal helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ HTMLBars template helpers for additional truth logic in `if` and `unless` statem
 Helper   | JavaScript                           | HTMLBars
 ---------|--------------------------------------|-------------------
 eq       | `if (a === b)`                       | `{{if (eq a b)}}`
+weq      | `if (a == b)`                        | `{{if (weq a b)}}`
 not-eq   | `if (a !== b)`                       | `{{if (not-eq a b)}}`
 not      | `if (!a)`                            | `{{if (not a)}}`
 and      | `if (a && b)`                        | `{{if (and a b)}}`

--- a/addon/helpers/weak-equal.js
+++ b/addon/helpers/weak-equal.js
@@ -1,0 +1,3 @@
+export function equalHelper(params) {
+  return params[0] == params[1];
+}

--- a/addon/helpers/weak-equal.js
+++ b/addon/helpers/weak-equal.js
@@ -1,3 +1,5 @@
 export function weakEqualHelper(params) {
+  /*jslint eqeq: true*/
   return params[0] == params[1];
+  /*jslint eqeq: false*/
 }

--- a/addon/helpers/weak-equal.js
+++ b/addon/helpers/weak-equal.js
@@ -1,3 +1,3 @@
-export function equalHelper(params) {
+export function weakEqualHelper(params) {
   return params[0] == params[1];
 }

--- a/app/helpers/weq.js
+++ b/app/helpers/weq.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import { weakEqualHelper } from 'ember-truth-helpers/helpers/weak-equal';
+
+var forExport = null;
+
+if (Ember.Helper) {
+  forExport = Ember.Helper.helper(weakEqualHelper);
+} else if (Ember.HTMLBars.makeBoundHelper) {
+  forExport = Ember.HTMLBars.makeBoundHelper(weakEqualHelper);
+}
+
+export default forExport;

--- a/app/initializers/truth-helpers.js
+++ b/app/initializers/truth-helpers.js
@@ -4,6 +4,7 @@ import { registerHelper } from 'ember-truth-helpers/utils/register-helper';
 import { andHelper } from 'ember-truth-helpers/helpers/and';
 import { orHelper } from 'ember-truth-helpers/helpers/or';
 import { equalHelper } from 'ember-truth-helpers/helpers/equal';
+import { weakEqualHelper } from 'ember-truth-helpers/helpers/weak-equal';
 import { notHelper } from 'ember-truth-helpers/helpers/not';
 import { isArrayHelper } from 'ember-truth-helpers/helpers/is-array';
 import { notEqualHelper } from 'ember-truth-helpers/helpers/not-equal';
@@ -23,6 +24,7 @@ export function initialize(/* container, application */) {
   registerHelper('and', andHelper);
   registerHelper('or', orHelper);
   registerHelper('eq', equalHelper);
+  registerHelper('weq', weakEqualHelper);
   registerHelper('not', notHelper);
   registerHelper('is-array', isArrayHelper);
   registerHelper('not-eq', notEqualHelper);

--- a/tests/unit/helpers/weak-equal-test.js
+++ b/tests/unit/helpers/weak-equal-test.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import { registerHelper } from 'ember-truth-helpers/utils/register-helper';
+import {
+  weakEqualHelper
+} from 'ember-truth-helpers/helpers/weak-equal';
+
+moduleForComponent('weq', 'helper:weq', {
+  integration: true,
+  beforeEach: function() {
+    // Do not register helpers from Ember 1.13 onwards, starting from 1.13 they
+    // will be auto-discovered.
+    if (!Ember.Helper) {
+      registerHelper('weq',weakEqualHelper);
+    }
+  }
+});
+
+test('simple test 1', function(assert) {
+  this.render(
+    Ember.HTMLBars.compile("[{{weq true true}}] [{{weq true false}}] [{{weq false true}}] [{{weq false false}}] [{{weq 1 1}}] [{{weq 1 '1'}}]")
+  );
+
+  assert.equal(this.$().text(), '[true] [false] [false] [true]', 'value should be "[true] [false] [false] [true] [true] [true]"');
+});
+
+test('simple test 2', function(assert) {
+  var fakeContextObject = Ember.Object.create({
+    valueA: null,
+    valueB: null
+  });
+
+  this.set('contextChild', fakeContextObject);
+
+  this.render(
+    Ember.HTMLBars.compile("[{{weq contextChild.valueA contextChild.valueB}}] [{{weq contextChild.valueB contextChild.valueA}}]")
+  );
+
+  assert.equal(this.$().text(), '[true] [true]', 'value should be "[true] [true]"');
+
+  Ember.run(fakeContextObject, 'set', 'valueA', undefined);
+  assert.equal(this.$().text(), '[true] [true]', 'value should be "[true] [true]"');
+
+  Ember.run(fakeContextObject, 'set', 'valueB', undefined);
+  assert.equal(this.$().text(), '[true] [true]', 'value should be "[true] [true]"');
+
+  Ember.run(fakeContextObject, 'set', 'valueA', 'yellow');
+  Ember.run(fakeContextObject, 'set', 'valueB', 'yellow');
+  assert.equal(this.$().text(), '[true] [true]', 'value should be "[true] [true]"');
+
+});


### PR DESCRIPTION
Many of the 3rd party APIs I work with are often not consistent with the their output data types.
For example, on one request the property "price" is a decimal number where on other it is a string.
The weak helper can help bypassing these kinds of glitches.