### PR TITLE
Warning for comparing different types

### DIFF
--- a/addon/helpers/equal.js
+++ b/addon/helpers/equal.js
@@ -1,3 +1,22 @@
+import Ember from 'ember';
+
 export function equalHelper(params) {
+  Ember.Logger.warn(areParamsSameType(params));
+
   return params[0] === params[1];
+}
+
+function areParamsSameType(params) {
+  const types = [];
+
+  params.forEach(param => {
+    const type = Ember.typeOf(param);
+    if (!types.includes(type) && ![null, undefined].includes(type)) {
+      types.push(type);
+    }
+  });
+
+  if (types.get('length') > 1) {
+    return `Strong equal of parameters with different types (${types.join(', ')}).`;
+  }
 }


### PR DESCRIPTION
What do you think about adding warning when comparing two different types like `{{eq '1' 1}}`? This PR does that. 

Although I can't find a way how to run the code only in development:
 - Assert is not desired as this may actually be valid use.
 - `Ember.Logger.warn` outputs, even when function returns `undefined` or `null`.
 - Guard around `warn` will make code run in production too.

