### PR TITLE
Add is-blank helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ gte      | `if (a >= b)`                        | `{{if (gte a b)}}`
 lt       | `if (a < b)`                         | `{{if (lt a b)}}`
 lte      | `if (a <= b)`                        | `{{if (lte a b)}}`
 is-array | `if (Ember.isArray(a))`              | `{{if (is-array a)}}`
+is-blank | `if (Ember.isBlank(a))`              | `{{if (is-blank a)}}`
 is-equal | `if (Ember.isEqual(a, b))`           | `{{if (is-equal a b)}}`
 
 ### API

--- a/addon/helpers/is-blank.js
+++ b/addon/helpers/is-blank.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export function isBlankHelper(params) {
+  return Ember.isBlank(params[0]);
+}

--- a/app/helpers/is-blank.js
+++ b/app/helpers/is-blank.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import { isBlankHelper } from 'ember-truth-helpers/helpers/is-blank';
+
+var forExport = null;
+
+if (Ember.Helper) {
+  forExport = Ember.Helper.helper(isBlankHelper);
+} else if (Ember.HTMLBars.makeBoundHelper) {
+  forExport = Ember.HTMLBars.makeBoundHelper(isBlankHelper);
+}
+
+export default forExport;

--- a/app/initializers/truth-helpers.js
+++ b/app/initializers/truth-helpers.js
@@ -11,6 +11,7 @@ import { gtHelper } from 'ember-truth-helpers/helpers/gt';
 import { gteHelper } from 'ember-truth-helpers/helpers/gte';
 import { ltHelper } from 'ember-truth-helpers/helpers/lt';
 import { lteHelper } from 'ember-truth-helpers/helpers/lte';
+import { isBlankHelper } from 'ember-truth-helpers/helpers/is-blank';
 
 export function initialize(/* container, application */) {
 
@@ -30,6 +31,7 @@ export function initialize(/* container, application */) {
   registerHelper('gte', gteHelper);
   registerHelper('lt', ltHelper);
   registerHelper('lte', lteHelper);
+  registerHelper('is-blank', isBlankHelper);
 }
 
 export default {

--- a/tests/unit/helpers/is-blank-test.js
+++ b/tests/unit/helpers/is-blank-test.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import { registerHelper } from 'ember-truth-helpers/utils/register-helper';
+import {
+  isBlankHelper
+} from 'ember-truth-helpers/helpers/is-blank';
+
+moduleForComponent('is-blank', 'helper:is-blank', {
+  integration: true,
+  beforeEach: function() {
+    // Do not register helpers from Ember 1.13 onwards, starting from 1.13 they
+    // will be auto-discovered.
+    if (!Ember.Helper) {
+      registerHelper('is-blank', isBlankHelper);
+    }
+  }
+});
+
+test('simple test 1', function(assert) {
+  this.render(
+    Ember.HTMLBars.compile("[{{is-blank '    '}}] [{{is-blank 'not blank'}}]")
+  );
+
+  assert.equal(this.$().text(), '[true] [false]', 'value should be "[true] [false]"');
+});


### PR DESCRIPTION
Not sure on your thoughts on this given the convo in #30 but I've found this useful in the following scenario:

```
input | save button
```

Save button is disabled unless the user enters content that is something besides a space character.

e.g.

`<button disabled={{is-blank someText}}>`