### PR TITLE
Add addons ember-load-initializers

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-resolver": "^2.0.3",
+    "ember-load-initializers": "^0.5.1",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-try": "~0.0.8",
     "loader.js": "^4.0.1"


### PR DESCRIPTION
This PR adds the addon **ember-load-initializers**.

This addon it's necessary for run **ember server**.

I want to create a webpage the example.