### PR TITLE
Add a 'More than two arguments allowed'-column

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ HTMLBars template helpers for additional truth logic in `if` and `unless` statem
 
 ## Usage
 
-Helper   | JavaScript                           | HTMLBars                | More than two arguments allowed |
+Helper   | JavaScript                           | HTMLBars                | Variable argument count allowed |
 ---------|--------------------------------------|-------------------------|---------------------------------|
 eq       | `if (a === b)`                       | `{{if (eq a b)}}`       | No                              |
 not-eq   | `if (a !== b)`                       | `{{if (not-eq a b)}}`   | No                              |

--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ HTMLBars template helpers for additional truth logic in `if` and `unless` statem
 
 ## Usage
 
-Helper   | JavaScript                           | HTMLBars
----------|--------------------------------------|-------------------
-eq       | `if (a === b)`                       | `{{if (eq a b)}}`
-not-eq   | `if (a !== b)`                       | `{{if (not-eq a b)}}`
-not      | `if (!a)`                            | `{{if (not a)}}`
-and      | `if (a && b)`                        | `{{if (and a b)}}`
-or       | `if (a || b)`                        | `{{if (or a b)}}`
-xor      | `if (a && !b || !a && b)`            | `{{if (xor a b)}}`
-gt       | `if (a > b)`                         | `{{if (gt a b)}}`
-gte      | `if (a >= b)`                        | `{{if (gte a b)}}`
-lt       | `if (a < b)`                         | `{{if (lt a b)}}`
-lte      | `if (a <= b)`                        | `{{if (lte a b)}}`
-is-array | `if (Ember.isArray(a))`              | `{{if (is-array a)}}`
-is-equal | `if (Ember.isEqual(a, b))`           | `{{if (is-equal a b)}}`
+Helper   | JavaScript                           | HTMLBars                | More than two arguments allowed |
+---------|--------------------------------------|-------------------------|---------------------------------|
+eq       | `if (a === b)`                       | `{{if (eq a b)}}`       | No                              |
+not-eq   | `if (a !== b)`                       | `{{if (not-eq a b)}}`   | No                              |
+not      | `if (!a)`                            | `{{if (not a)}}`        | Yes                             |
+and      | `if (a && b)`                        | `{{if (and a b)}}`      | Yes                             |
+or       | `if (a || b)`                        | `{{if (or a b)}}`       | Yes                             |
+xor      | `if (a && !b || !a && b)`            | `{{if (xor a b)}}`      | No                              |
+gt       | `if (a > b)`                         | `{{if (gt a b)}}`       | No                              |
+gte      | `if (a >= b)`                        | `{{if (gte a b)}}`      | No                              |
+lt       | `if (a < b)`                         | `{{if (lt a b)}}`       | No                              |
+lte      | `if (a <= b)`                        | `{{if (lte a b)}}`      | No                              |
+is-array | `if (Ember.isArray(a))`              | `{{if (is-array a)}}`   | Yes                             |
+is-equal | `if (Ember.isEqual(a, b))`           | `{{if (is-equal a b)}}` | No                              |
 
 ### API
 


### PR DESCRIPTION
Add a column to document multiple arguments are allowed in some cases (e.g. `{{if (and param1 param2 param3)}}`)