### PR TITLE
Use template strings intstead of string literals with htmbars-inline-precompile

### DIFF
--- a/tests/unit/helpers/and-test.js
+++ b/tests/unit/helpers/and-test.js
@@ -7,26 +7,26 @@ module('helper:and', function(hooks) {
   setupRenderingTest(hooks);
 
   test('boolean values', async function(assert) {
-    await render(hbs("[{{and true true}}] [{{and true false}}] [{{and false true}}] [{{and false false}}]"));
+    await render(hbs`[{{and true true}}] [{{and true false}}] [{{and false true}}] [{{and false false}}]`);
 
     assert.equal(find('*').textContent, '[true] [false] [false] [false]', 'value should be "[true] [false] [false] [false]"');
   });
 
   test('integer values', async function(assert) {
-    await render(hbs("[{{and 1 1}}] [{{and 1 0}}] [{{and 0 1}}] [{{and 0 0}}]"));
+    await render(hbs`[{{and 1 1}}] [{{and 1 0}}] [{{and 0 1}}] [{{and 0 0}}]`);
 
     assert.equal(find('*').textContent, '[1] [0] [0] [0]', 'value should be "[1] [0] [0] [0]"');
   });
 
   test('string values', async function(assert) {
-    await render(hbs('[{{and " " " "}}] [{{and " " ""}}] [{{and "" " "}}] [{{and "" ""}}]'));
+    await render(hbs`[{{and " " " "}}] [{{and " " ""}}] [{{and "" " "}}] [{{and "" ""}}]`);
 
     assert.equal(find('*').textContent, '[ ] [] [] []', 'value should be "[ ] [] [] []"');
   });
 
 
   test('undefined list length and boolean', async function(assert) {
-    await render(hbs('[{{and array.length 1}}]'));
+    await render(hbs`[{{and array.length 1}}]`);
 
     assert.equal(find('*').textContent, '[]', 'value should be "[]"');
   });
@@ -34,7 +34,7 @@ module('helper:and', function(hooks) {
   test('null list length and boolean', async function(assert) {
     this.set('array', null);
 
-    await render(hbs('[{{and array.length 1}}]'));
+    await render(hbs`[{{and array.length 1}}]`);
 
     assert.equal(find('*').textContent, '[]', 'value should be "[]"');
   });
@@ -42,7 +42,7 @@ module('helper:and', function(hooks) {
   test('empty list length and boolean', async function(assert) {
     this.set('array', []);
 
-    await render(hbs('[{{and array.length 1}}]'));
+    await render(hbs`[{{and array.length 1}}]`);
 
     assert.equal(find('*').textContent, '[0]', 'value should be "[0]"');
   });
@@ -50,7 +50,7 @@ module('helper:and', function(hooks) {
   test('non-empty list length and boolean', async function(assert) {
     this.set('array', ['a']);
 
-    await render(hbs('[{{and array.length 2}}]'));
+    await render(hbs`[{{and array.length 2}}]`);
 
     assert.equal(find('*').textContent, '[2]', 'value should be "[2]"');
   });

--- a/tests/unit/helpers/equal-test.js
+++ b/tests/unit/helpers/equal-test.js
@@ -9,7 +9,7 @@ module('helper:eq', function(hooks) {
   setupRenderingTest(hooks);
 
   test('simple test 1', async function(assert) {
-    await render(hbs("[{{eq true true}}] [{{eq true false}}] [{{eq false true}}] [{{eq false false}}]"));
+    await render(hbs`[{{eq true true}}] [{{eq true false}}] [{{eq false true}}] [{{eq false false}}]`);
 
     assert.equal(find('*').textContent, '[true] [false] [false] [true]', 'value should be "[true] [false] [false] [true]"');
   });
@@ -23,7 +23,7 @@ module('helper:eq', function(hooks) {
     this.set('contextChild', fakeContextObject);
 
     await render(
-      hbs("[{{eq contextChild.valueA contextChild.valueB}}] [{{eq contextChild.valueB contextChild.valueA}}]")
+      hbs`[{{eq contextChild.valueA contextChild.valueB}}] [{{eq contextChild.valueB contextChild.valueA}}]`
     );
 
     assert.equal(find('*').textContent, '[true] [true]', 'value should be "[true] [true]"');

--- a/tests/unit/helpers/gt-test.js
+++ b/tests/unit/helpers/gt-test.js
@@ -7,26 +7,26 @@ module('helper:gt', function(hooks) {
   setupRenderingTest(hooks);
 
   test('boolean values', async function(assert) {
-    await render(hbs(("[{{gt true true}}] [{{gt true false}}] [{{gt false true}}] [{{gt false false}}]")));
+    await render(hbs`[{{gt true true}}] [{{gt true false}}] [{{gt false true}}] [{{gt false false}}]`);
 
     assert.equal(find('*').textContent, '[false] [true] [false] [false]', 'value should be "[false] [true] [false] [false]"');
   });
 
   test('integer values', async function(assert) {
-    await render(hbs("[{{gt 1 1}}] [{{gt 1 0}}] [{{gt 0 1}}] [{{gt 0 0}}]"));
+    await render(hbs`[{{gt 1 1}}] [{{gt 1 0}}] [{{gt 0 1}}] [{{gt 0 0}}]`);
 
     assert.equal(find('*').textContent, '[false] [true] [false] [false]', 'value should be "[false] [true] [false] [false]"');
   });
 
   test('decimal values', async function(assert) {
-    await render(hbs("[{{gt 19.2 19.2}}] [{{gt 19.2 3.55}}] [{{gt 3.55 19.2}}] [{{gt 3.55 3.55}}]"));
+    await render(hbs`[{{gt 19.2 19.2}}] [{{gt 19.2 3.55}}] [{{gt 3.55 19.2}}] [{{gt 3.55 3.55}}]`);
 
     assert.equal(find('*').textContent, '[false] [true] [false] [false]', 'value should be "[false] [true] [false] [false]"');
   });
 
   test('integers in strings 1', async function(assert) {
     await render(
-      hbs("[{{gt '1' '1' forceNumber=true}}] [{{gt '1' '0' forceNumber=true}}] [{{gt '0' '1' forceNumber=true}}] [{{gt '0' '0' forceNumber=true}}]")
+      hbs`[{{gt '1' '1' forceNumber=true}}] [{{gt '1' '0' forceNumber=true}}] [{{gt '0' '1' forceNumber=true}}] [{{gt '0' '0' forceNumber=true}}]`
     );
 
     assert.equal(find('*').textContent, '[false] [true] [false] [false]', 'value should be "[false] [true] [false] [false]"');
@@ -34,7 +34,7 @@ module('helper:gt', function(hooks) {
 
   test('integers in strings 2', async function(assert) {
     await render(
-      hbs("[{{gt '102' '102' forceNumber=true}}] [{{gt '102' '98' forceNumber=true}}] [{{gt '98' '102' forceNumber=true}}] [{{gt '98' '98' forceNumber=true}}]")
+      hbs`[{{gt '102' '102' forceNumber=true}}] [{{gt '102' '98' forceNumber=true}}] [{{gt '98' '102' forceNumber=true}}] [{{gt '98' '98' forceNumber=true}}]`
     );
 
     assert.equal(find('*').textContent, '[false] [true] [false] [false]', 'value should be "[false] [true] [false] [false]"');
@@ -42,7 +42,7 @@ module('helper:gt', function(hooks) {
 
   test('decimals in strings', async function(assert) {
     await render(
-      hbs("[{{gt '19.2' '19.2' forceNumber=true}}] [{{gt '19.2' '3.55' forceNumber=true}}] [{{gt '3.55' '19.2' forceNumber=true}}] [{{gt '3.55' '3.55' forceNumber=true}}]")
+      hbs`[{{gt '19.2' '19.2' forceNumber=true}}] [{{gt '19.2' '3.55' forceNumber=true}}] [{{gt '3.55' '19.2' forceNumber=true}}] [{{gt '3.55' '3.55' forceNumber=true}}]`
     );
 
     assert.equal(find('*').textContent, '[false] [true] [false] [false]', 'value should be "[false] [true] [false] [false]"');

--- a/tests/unit/helpers/gte-test.js
+++ b/tests/unit/helpers/gte-test.js
@@ -7,26 +7,26 @@ module('helper:gte', function(hooks) {
   setupRenderingTest(hooks);
 
   test('boolean values', async function(assert) {
-    await render(hbs("[{{gte true true}}] [{{gte true false}}] [{{gte false true}}] [{{gte false false}}]"));
+    await render(hbs`[{{gte true true}}] [{{gte true false}}] [{{gte false true}}] [{{gte false false}}]`);
 
     assert.equal(find('*').textContent, '[true] [true] [false] [true]', 'value should be "[false] [true] [false] [true]"');
   });
 
   test('integer values', async function(assert) {
-    await render(hbs("[{{gte 1 1}}] [{{gte 1 0}}] [{{gte 0 1}}] [{{gte 0 0}}]"));
+    await render(hbs`[{{gte 1 1}}] [{{gte 1 0}}] [{{gte 0 1}}] [{{gte 0 0}}]`);
 
     assert.equal(find('*').textContent, '[true] [true] [false] [true]', 'value should be "[true] [true] [false] [true]"');
   });
 
   test('decimal values', async function(assert) {
-    await render(hbs("[{{gte 19.2 19.2}}] [{{gte 19.2 3.55}}] [{{gte 3.55 19.2}}] [{{gte 3.55 3.55}}]"));
+    await render(hbs`[{{gte 19.2 19.2}}] [{{gte 19.2 3.55}}] [{{gte 3.55 19.2}}] [{{gte 3.55 3.55}}]`);
 
     assert.equal(find('*').textContent, '[true] [true] [false] [true]', 'value should be "[true] [true] [false] [true]"');
   });
 
   test('integers in strings 1', async function(assert) {
     await render(
-      hbs("[{{gte '1' '1' forceNumber=true}}] [{{gte '1' '0' forceNumber=true}}] [{{gte '0' '1' forceNumber=true}}] [{{gte '0' '0' forceNumber=true}}]")
+      hbs`[{{gte '1' '1' forceNumber=true}}] [{{gte '1' '0' forceNumber=true}}] [{{gte '0' '1' forceNumber=true}}] [{{gte '0' '0' forceNumber=true}}]`
     );
 
     assert.equal(find('*').textContent, '[true] [true] [false] [true]', 'value should be "[true] [true] [false] [true]"');
@@ -34,7 +34,7 @@ module('helper:gte', function(hooks) {
 
   test('integers in strings 2', async function(assert) {
     await render(
-      hbs("[{{gte '102' '102' forceNumber=true}}] [{{gte '102' '98' forceNumber=true}}] [{{gte '98' '102' forceNumber=true}}] [{{gte '98' '98' forceNumber=true}}]")
+      hbs`[{{gte '102' '102' forceNumber=true}}] [{{gte '102' '98' forceNumber=true}}] [{{gte '98' '102' forceNumber=true}}] [{{gte '98' '98' forceNumber=true}}]`
     );
 
     assert.equal(find('*').textContent, '[true] [true] [false] [true]', 'value should be "[true] [true] [false] [true]"');
@@ -42,7 +42,7 @@ module('helper:gte', function(hooks) {
 
   test('decimals in strings', async function(assert) {
     await render(
-      hbs("[{{gte '19.2' '19.2' forceNumber=true}}] [{{gte '19.2' '3.55' forceNumber=true}}] [{{gte '3.55' '19.2' forceNumber=true}}] [{{gte '3.55' '3.55' forceNumber=true}}]")
+      hbs`[{{gte '19.2' '19.2' forceNumber=true}}] [{{gte '19.2' '3.55' forceNumber=true}}] [{{gte '3.55' '19.2' forceNumber=true}}] [{{gte '3.55' '3.55' forceNumber=true}}]`
     );
 
     assert.equal(find('*').textContent, '[true] [true] [false] [true]', 'value should be "[true] [true] [false] [true]"');

--- a/tests/unit/helpers/is-array-test.js
+++ b/tests/unit/helpers/is-array-test.js
@@ -16,7 +16,7 @@ module('helper:is-array', function(hooks) {
     this.set('contextChild', fakeContextObject);
 
     await render(
-      hbs("[{{is-array contextChild.valueA}}] [{{is-array contextChild.valueB}}] [{{is-array contextChild.valueA contextChild.valueB}}]")
+      hbs`[{{is-array contextChild.valueA}}] [{{is-array contextChild.valueB}}] [{{is-array contextChild.valueA contextChild.valueB}}]`
     );
 
     assert.equal(find('*').textContent, '[false] [false] [false]', 'value should be "[false] [false] [false]"');

--- a/tests/unit/helpers/is-empty-test.js
+++ b/tests/unit/helpers/is-empty-test.js
@@ -10,13 +10,13 @@ module('helper:is-empty', function(hooks) {
     this.set('thisIsUndefined', undefined)
     this.set('thisIsNull', null)
     this.set('thisIsNotNull', new Date())
-    await render(hbs("[{{is-empty thisIsUndefined}}] [{{is-empty thisIsNull}}] [{{is-empty thisIsNotNull}}]"));
+    await render(hbs`[{{is-empty thisIsUndefined}}] [{{is-empty thisIsNull}}] [{{is-empty thisIsNotNull}}]`);
 
     assert.equal(find('*').textContent, '[true] [true] [false]', 'value should be "[true] [true] [false]"');
   });
 
   test('boolean values', async function(assert) {
-    await render(hbs("[{{is-empty true}}] [{{is-empty false}}]"));
+    await render(hbs`[{{is-empty true}}] [{{is-empty false}}]`);
 
     assert.equal(find('*').textContent, '[false] [false]', 'value should be "[false] [false]"');
   });
@@ -24,7 +24,7 @@ module('helper:is-empty', function(hooks) {
   test('objects', async function(assert) {
     this.set('emptyObject', {})
     this.set('notEmptyObject', { some: 'object' })
-    await render(hbs("[{{is-empty emptyObject}}] [{{is-empty notEmptyObject}}]"));
+    await render(hbs`[{{is-empty emptyObject}}] [{{is-empty notEmptyObject}}]`);
 
     assert.equal(find('*').textContent, '[false] [false]', 'value should be "[false] [false]"');
   });
@@ -32,7 +32,7 @@ module('helper:is-empty', function(hooks) {
   test('arrays', async function(assert) {
     this.set('emptyArray', [])
     this.set('notEmptyArray', [ 'a', 8, {} ])
-    await render(hbs("[{{is-empty emptyArray}}] [{{is-empty notEmptyArray}}]"));
+    await render(hbs`[{{is-empty emptyArray}}] [{{is-empty notEmptyArray}}]`);
 
     assert.equal(find('*').textContent, '[true] [false]', 'value should be "[true] [false]"');
   });
@@ -41,7 +41,7 @@ module('helper:is-empty', function(hooks) {
     this.set('emptyString', '')
     this.set('whitespaceString', '   ')
     this.set('notEmptyString', 'full of text')
-    await render(hbs("[{{is-empty emptyString}}] [{{is-empty whitespaceString}}] [{{is-empty notEmptyString}}]"));
+    await render(hbs`[{{is-empty emptyString}}] [{{is-empty whitespaceString}}] [{{is-empty notEmptyString}}]`);
 
     assert.equal(find('*').textContent, '[true] [false] [false]', 'value should be "[true] [false] [false]"');
   });

--- a/tests/unit/helpers/is-equal-test.js
+++ b/tests/unit/helpers/is-equal-test.js
@@ -14,7 +14,7 @@ module('helper:is-equal', function(hooks) {
     });
 
     await render(
-      hbs("[{{is-equal complex 12}}] [{{is-equal complex 13}}] [{{is-equal 13 complex}}] [{{is-equal 12 complex}}]")
+      hbs`[{{is-equal complex 12}}] [{{is-equal complex 13}}] [{{is-equal 13 complex}}] [{{is-equal 12 complex}}]`
     );
 
     assert.equal(find('*').textContent, '[true] [false] [false] [false]', 'value should be "[true] [false] [false] [false]"');

--- a/tests/unit/helpers/lt-test.js
+++ b/tests/unit/helpers/lt-test.js
@@ -8,26 +8,26 @@ module('helper:lt', function(hooks) {
 
   // Replace this with your real tests.
   test('boolean values', async function(assert) {
-    await render(hbs("[{{lt true true}}] [{{lt true false}}] [{{lt false true}}] [{{lt false false}}]"));
+    await render(hbs`[{{lt true true}}] [{{lt true false}}] [{{lt false true}}] [{{lt false false}}]`);
 
     assert.equal(find('*').textContent, '[false] [false] [true] [false]', 'value should be "[false] [false] [true] [false]"');
   });
 
   test('integer values', async function(assert) {
-    await render(hbs("[{{lt 1 1}}] [{{lt 1 0}}] [{{lt 0 1}}] [{{lt 0 0}}]"));
+    await render(hbs`[{{lt 1 1}}] [{{lt 1 0}}] [{{lt 0 1}}] [{{lt 0 0}}]`);
 
     assert.equal(find('*').textContent, '[false] [false] [true] [false]', 'value should be "[false] [false] [true] [false]"');
   });
 
   test('decimal values', async function(assert) {
-    await render(hbs("[{{lt 19.2 19.2}}] [{{lt 19.2 3.55}}] [{{lt 3.55 19.2}}] [{{lt 3.55 3.55}}]"));
+    await render(hbs`[{{lt 19.2 19.2}}] [{{lt 19.2 3.55}}] [{{lt 3.55 19.2}}] [{{lt 3.55 3.55}}]`);
 
     assert.equal(find('*').textContent, '[false] [false] [true] [false]', 'value should be "[false] [false] [true] [false]"');
   });
 
   test('integers in strings 1', async function(assert) {
     await render(
-      hbs("[{{lt '1' '1' forceNumber=true}}] [{{lt '1' '0' forceNumber=true}}] [{{lt '0' '1' forceNumber=true}}] [{{lt '0' '0' forceNumber=true}}]")
+      hbs`[{{lt '1' '1' forceNumber=true}}] [{{lt '1' '0' forceNumber=true}}] [{{lt '0' '1' forceNumber=true}}] [{{lt '0' '0' forceNumber=true}}]`
     );
 
     assert.equal(find('*').textContent, '[false] [false] [true] [false]', 'value should be "[false] [false] [true] [false]"');
@@ -35,7 +35,7 @@ module('helper:lt', function(hooks) {
 
   test('integers in strings 2', async function(assert) {
     await render(
-      hbs("[{{lt '102' '102' forceNumber=true}}] [{{lt '102' '98' forceNumber=true}}] [{{lt '98' '102' forceNumber=true}}] [{{lt '98' '98' forceNumber=true}}]")
+      hbs`[{{lt '102' '102' forceNumber=true}}] [{{lt '102' '98' forceNumber=true}}] [{{lt '98' '102' forceNumber=true}}] [{{lt '98' '98' forceNumber=true}}]`
     );
 
     assert.equal(find('*').textContent, '[false] [false] [true] [false]', 'value should be "[false] [false] [true] [false]"');
@@ -43,7 +43,7 @@ module('helper:lt', function(hooks) {
 
   test('decimals in strings', async function(assert) {
     await render(
-      hbs("[{{lt '19.2' '19.2' forceNumber=true}}] [{{lt '19.2' '3.55' forceNumber=true}}] [{{lt '3.55' '19.2' forceNumber=true}}] [{{lt '3.55' '3.55' forceNumber=true}}]")
+      hbs`[{{lt '19.2' '19.2' forceNumber=true}}] [{{lt '19.2' '3.55' forceNumber=true}}] [{{lt '3.55' '19.2' forceNumber=true}}] [{{lt '3.55' '3.55' forceNumber=true}}]`
     );
 
     assert.equal(find('*').textContent, '[false] [false] [true] [false]', 'value should be "[false] [false] [true] [false]"');

--- a/tests/unit/helpers/lte-test.js
+++ b/tests/unit/helpers/lte-test.js
@@ -8,26 +8,26 @@ module('helper:lte', function(hooks) {
 
   // Replace this with your real tests.
   test('boolean values', async function(assert) {
-    await render(hbs("[{{lte true true}}] [{{lte true false}}] [{{lte false true}}] [{{lte false false}}]"));
+    await render(hbs`[{{lte true true}}] [{{lte true false}}] [{{lte false true}}] [{{lte false false}}]`);
 
     assert.equal(find('*').textContent, '[true] [false] [true] [true]', 'value should be "[false] [false] [true] [true]"');
   });
 
   test('integer values', async function(assert) {
-    await render(hbs("[{{lte 1 1}}] [{{lte 1 0}}] [{{lte 0 1}}] [{{lte 0 0}}]"));
+    await render(hbs`[{{lte 1 1}}] [{{lte 1 0}}] [{{lte 0 1}}] [{{lte 0 0}}]`);
 
     assert.equal(find('*').textContent, '[true] [false] [true] [true]', 'value should be "[false] [false] [true] [true]"');
   });
 
   test('decimal values', async function(assert) {
-    await render(hbs("[{{lte 19.2 19.2}}] [{{lte 19.2 3.55}}] [{{lte 3.55 19.2}}] [{{lte 3.55 3.55}}]"));
+    await render(hbs`[{{lte 19.2 19.2}}] [{{lte 19.2 3.55}}] [{{lte 3.55 19.2}}] [{{lte 3.55 3.55}}]`);
 
     assert.equal(find('*').textContent, '[true] [false] [true] [true]', 'value should be "[false] [false] [true] [true]"');
   });
 
   test('integers in strings 1', async function(assert) {
     await render(
-      hbs("[{{lte '1' '1' forceNumber=true}}] [{{lte '1' '0' forceNumber=true}}] [{{lte '0' '1' forceNumber=true}}] [{{lte '0' '0' forceNumber=true}}]")
+      hbs`[{{lte '1' '1' forceNumber=true}}] [{{lte '1' '0' forceNumber=true}}] [{{lte '0' '1' forceNumber=true}}] [{{lte '0' '0' forceNumber=true}}]`
     );
 
     assert.equal(find('*').textContent, '[true] [false] [true] [true]', 'value should be "[false] [false] [true] [true]"');
@@ -35,7 +35,7 @@ module('helper:lte', function(hooks) {
 
   test('integers in strings 2', async function(assert) {
     await render(
-      hbs("[{{lte '102' '102' forceNumber=true}}] [{{lte '102' '98' forceNumber=true}}] [{{lte '98' '102' forceNumber=true}}] [{{lte '98' '98' forceNumber=true}}]")
+      hbs`[{{lte '102' '102' forceNumber=true}}] [{{lte '102' '98' forceNumber=true}}] [{{lte '98' '102' forceNumber=true}}] [{{lte '98' '98' forceNumber=true}}]`
     );
 
     assert.equal(find('*').textContent, '[true] [false] [true] [true]', 'value should be "[false] [false] [true] [true]"');
@@ -43,7 +43,7 @@ module('helper:lte', function(hooks) {
 
   test('decimals in strings', async function(assert) {
     await render(
-      hbs("[{{lte '19.2' '19.2' forceNumber=true}}] [{{lte '19.2' '3.55' forceNumber=true}}] [{{lte '3.55' '19.2' forceNumber=true}}] [{{lte '3.55' '3.55' forceNumber=true}}]")
+      hbs`[{{lte '19.2' '19.2' forceNumber=true}}] [{{lte '19.2' '3.55' forceNumber=true}}] [{{lte '3.55' '19.2' forceNumber=true}}] [{{lte '3.55' '3.55' forceNumber=true}}]`
     );
 
     assert.equal(find('*').textContent, '[true] [false] [true] [true]', 'value should be "[false] [false] [true] [true]"');

--- a/tests/unit/helpers/not-equal-test.js
+++ b/tests/unit/helpers/not-equal-test.js
@@ -10,7 +10,7 @@ module('helper:not-equal', function(hooks) {
 
   test('simple test 1', async function(assert) {
     await render(
-      hbs("[{{not-eq true true}}] [{{not-eq true false}}] [{{not-eq false true}}] [{{not-eq false false}}]")
+      hbs`[{{not-eq true true}}] [{{not-eq true false}}] [{{not-eq false true}}] [{{not-eq false false}}]`
     );
 
     assert.equal(find('*').textContent, '[false] [true] [true] [false]', 'value should be "[false] [true] [true] [false]"');
@@ -25,7 +25,7 @@ module('helper:not-equal', function(hooks) {
     this.set('contextChild', fakeContextObject);
 
     await render(
-      hbs("[{{not-eq contextChild.valueA contextChild.valueB}}] [{{not-eq contextChild.valueB contextChild.valueA}}]")
+      hbs`[{{not-eq contextChild.valueA contextChild.valueB}}] [{{not-eq contextChild.valueB contextChild.valueA}}]`
     );
 
     assert.equal(find('*').textContent, '[false] [false]', 'value should be "[false] [false]"');

--- a/tests/unit/helpers/not-test.js
+++ b/tests/unit/helpers/not-test.js
@@ -7,14 +7,14 @@ module('helper:not', function(hooks) {
   setupRenderingTest(hooks);
 
   test('simple test 1', async function(assert) {
-    await render(hbs("[{{not true}}] [{{not false}}] [{{not null}}] [{{not undefined}}] [{{not ''}}] [{{not ' '}}]"));
+    await render(hbs`[{{not true}}] [{{not false}}] [{{not null}}] [{{not undefined}}] [{{not ''}}] [{{not ' '}}]`);
 
     assert.equal(find('*').textContent, '[false] [true] [true] [true] [true] [false]', 'value should be "[false] [true] [true] [true] [true] [false]"');
   });
 
   test('simple test 2', async function(assert) {
     await render(
-      hbs("[{{not true false}}] [{{not true false}}] [{{not null null false null}}] [{{not false null ' ' true}}]")
+      hbs`[{{not true false}}] [{{not true false}}] [{{not null null false null}}] [{{not false null ' ' true}}]`
     );
 
     assert.equal(find('*').textContent, '[false] [false] [true] [false]', 'value should be "[false] [false] [true] [false]"');

--- a/tests/unit/helpers/or-test.js
+++ b/tests/unit/helpers/or-test.js
@@ -9,13 +9,13 @@ module('helper:or', function(hooks) {
   setupRenderingTest(hooks);
 
   test('simple test 1', async function(assert) {
-    await render(hbs("[{{or true 1 ' ' null undefined}}]"));
+    await render(hbs`[{{or true 1 ' ' null undefined}}]`);
 
     assert.equal(find('*').textContent, '[true]', 'value should be "[true]"');
   });
 
   test('simple test 2', async function(assert) {
-    await render(hbs("[{{or null undefined true 1 ' '}}]"));
+    await render(hbs`[{{or null undefined true 1 ' '}}]`);
 
     assert.equal(find('*').textContent, '[true]', 'value should be "[true]"');
   });
@@ -23,7 +23,7 @@ module('helper:or', function(hooks) {
 
   test('simple test 3', async function(assert) {
     await render(
-      hbs("[{{or false}}] [{{or true}}] [{{or 1}}] [{{or ''}}] [{{or false ''}}] [{{or true ''}}] [{{or '' true}}]")
+      hbs`[{{or false}}] [{{or true}}] [{{or 1}}] [{{or ''}}] [{{or false ''}}] [{{or true ''}}] [{{or '' true}}]`
     );
 
     assert.equal(find('*').textContent, '[false] [true] [1] [] [] [true] [true]', 'value should be "[false] [true] [1] [] [] [true] [true]"');
@@ -38,7 +38,7 @@ module('helper:or', function(hooks) {
     this.set('contextChild', fakeContextObject);
 
     await render(
-      hbs("[{{or contextChild.valueA}}] [{{or contextChild.valueB}}] [{{or contextChild.valueB contextChild.valueA}}] [{{or contextChild.valueA contextChild.valueB}}]")
+      hbs`[{{or contextChild.valueA}}] [{{or contextChild.valueB}}] [{{or contextChild.valueB contextChild.valueA}}] [{{or contextChild.valueA contextChild.valueB}}]`
     );
 
     assert.equal(find('*').textContent, '[] [] [] []', 'value should be "[] [] [] []"');

--- a/tests/unit/helpers/or-with-not-eq-test.js
+++ b/tests/unit/helpers/or-with-not-eq-test.js
@@ -7,31 +7,31 @@ module('helper:or', function(hooks) {
   setupRenderingTest(hooks);
 
   test('simple test 1', async function(assert) {
-    await render(hbs("[{{or (not-eq true false) (not-eq true false)}}]"));
+    await render(hbs`[{{or (not-eq true false) (not-eq true false)}}]`);
 
     assert.equal(find('*').textContent, '[true]', 'value should be "[true]"');
   });
 
   test('simple test 2', async function(assert) {
-    await render(hbs("[{{or (not-eq true true) (not-eq false false)}}]"));
+    await render(hbs`[{{or (not-eq true true) (not-eq false false)}}]`);
 
     assert.equal(find('*').textContent, '[false]', 'value should be "[true]"');
   });
 
   test('simple test 3', async function(assert) {
-    await render(hbs("[{{or (not-eq true true) (not-eq true false)}}]"));
+    await render(hbs`[{{or (not-eq true true) (not-eq true false)}}]`);
 
     assert.equal(find('*').textContent, '[true]', 'value should be "[true]"');
   });
 
   test('simple test 4', async function(assert) {
-    await render(hbs("[{{or (not-eq true false) (not-eq false false)}}]"));
+    await render(hbs`[{{or (not-eq true false) (not-eq false false)}}]`);
 
     assert.equal(find('*').textContent, '[true]', 'value should be "[true]"');
   });
 
   test('simple test 5', async function(assert) {
-    await render(hbs("[{{#if (or (not-eq true false) (not-eq false false))}}true{{else}}false{{/if}}]"));
+    await render(hbs`[{{#if (or (not-eq true false) (not-eq false false))}}true{{else}}false{{/if}}]`);
 
     assert.equal(find('*').textContent, '[true]', 'value should be "[true]"');
   });

--- a/tests/unit/helpers/xor-test.js
+++ b/tests/unit/helpers/xor-test.js
@@ -7,7 +7,7 @@ module('helper:xor', function(hooks) {
   setupRenderingTest(hooks);
 
   test('boolean values', async function(assert) {
-    await render(hbs("[{{xor true true}}] [{{xor true false}}] [{{xor false true}}] [{{xor false false}}]"));
+    await render(hbs`[{{xor true true}}] [{{xor true false}}] [{{xor false true}}] [{{xor false false}}]`);
 
     assert.equal(find('*').textContent, '[false] [true] [true] [false]', 'value should be "[false] [true] [true] [false]"');
   });


### PR DESCRIPTION
In htmlbars-inline-precompile both string literals and template strings
are supported, but in `glimmer-inline-precompile` you may only pass a
template literal.

I ran a codemod to change all these in our unit tests to bring this in
line to the other precompile lib