### PR TITLE
Add assert expects to tests

### DIFF
--- a/tests/unit/helpers/and-test.js
+++ b/tests/unit/helpers/and-test.js
@@ -7,18 +7,21 @@ module('helper:and', function(hooks) {
   setupRenderingTest(hooks);
 
   test('boolean values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{and true true}}] [{{and true false}}] [{{and false true}}] [{{and false false}}]`);
 
     assert.equal(find('*').textContent, '[true] [false] [false] [false]', 'value should be "[true] [false] [false] [false]"');
   });
 
   test('integer values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{and 1 1}}] [{{and 1 0}}] [{{and 0 1}}] [{{and 0 0}}]`);
 
     assert.equal(find('*').textContent, '[1] [0] [0] [0]', 'value should be "[1] [0] [0] [0]"');
   });
 
   test('string values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{and " " " "}}] [{{and " " ""}}] [{{and "" " "}}] [{{and "" ""}}]`);
 
     assert.equal(find('*').textContent, '[ ] [] [] []', 'value should be "[ ] [] [] []"');
@@ -26,12 +29,14 @@ module('helper:and', function(hooks) {
 
 
   test('undefined list length and boolean', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{and array.length 1}}]`);
 
     assert.equal(find('*').textContent, '[]', 'value should be "[]"');
   });
 
   test('null list length and boolean', async function(assert) {
+    assert.expect(1);
     this.set('array', null);
 
     await render(hbs`[{{and array.length 1}}]`);
@@ -40,6 +45,7 @@ module('helper:and', function(hooks) {
   });
 
   test('empty list length and boolean', async function(assert) {
+    assert.expect(1);
     this.set('array', []);
 
     await render(hbs`[{{and array.length 1}}]`);
@@ -48,6 +54,7 @@ module('helper:and', function(hooks) {
   });
 
   test('non-empty list length and boolean', async function(assert) {
+    assert.expect(1);
     this.set('array', ['a']);
 
     await render(hbs`[{{and array.length 2}}]`);

--- a/tests/unit/helpers/equal-test.js
+++ b/tests/unit/helpers/equal-test.js
@@ -9,12 +9,14 @@ module('helper:eq', function(hooks) {
   setupRenderingTest(hooks);
 
   test('simple test 1', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{eq true true}}] [{{eq true false}}] [{{eq false true}}] [{{eq false false}}]`);
 
     assert.equal(find('*').textContent, '[true] [false] [false] [true]', 'value should be "[true] [false] [false] [true]"');
   });
 
   test('simple test 2', async function(assert) {
+    assert.expect(4);
     const fakeContextObject = EmberObject.create({
       valueA: null,
       valueB: null

--- a/tests/unit/helpers/gt-test.js
+++ b/tests/unit/helpers/gt-test.js
@@ -7,24 +7,28 @@ module('helper:gt', function(hooks) {
   setupRenderingTest(hooks);
 
   test('boolean values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{gt true true}}] [{{gt true false}}] [{{gt false true}}] [{{gt false false}}]`);
 
     assert.equal(find('*').textContent, '[false] [true] [false] [false]', 'value should be "[false] [true] [false] [false]"');
   });
 
   test('integer values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{gt 1 1}}] [{{gt 1 0}}] [{{gt 0 1}}] [{{gt 0 0}}]`);
 
     assert.equal(find('*').textContent, '[false] [true] [false] [false]', 'value should be "[false] [true] [false] [false]"');
   });
 
   test('decimal values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{gt 19.2 19.2}}] [{{gt 19.2 3.55}}] [{{gt 3.55 19.2}}] [{{gt 3.55 3.55}}]`);
 
     assert.equal(find('*').textContent, '[false] [true] [false] [false]', 'value should be "[false] [true] [false] [false]"');
   });
 
   test('integers in strings 1', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{gt '1' '1' forceNumber=true}}] [{{gt '1' '0' forceNumber=true}}] [{{gt '0' '1' forceNumber=true}}] [{{gt '0' '0' forceNumber=true}}]`
     );
@@ -33,6 +37,7 @@ module('helper:gt', function(hooks) {
   });
 
   test('integers in strings 2', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{gt '102' '102' forceNumber=true}}] [{{gt '102' '98' forceNumber=true}}] [{{gt '98' '102' forceNumber=true}}] [{{gt '98' '98' forceNumber=true}}]`
     );
@@ -41,6 +46,7 @@ module('helper:gt', function(hooks) {
   });
 
   test('decimals in strings', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{gt '19.2' '19.2' forceNumber=true}}] [{{gt '19.2' '3.55' forceNumber=true}}] [{{gt '3.55' '19.2' forceNumber=true}}] [{{gt '3.55' '3.55' forceNumber=true}}]`
     );

--- a/tests/unit/helpers/gte-test.js
+++ b/tests/unit/helpers/gte-test.js
@@ -7,24 +7,28 @@ module('helper:gte', function(hooks) {
   setupRenderingTest(hooks);
 
   test('boolean values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{gte true true}}] [{{gte true false}}] [{{gte false true}}] [{{gte false false}}]`);
 
     assert.equal(find('*').textContent, '[true] [true] [false] [true]', 'value should be "[false] [true] [false] [true]"');
   });
 
   test('integer values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{gte 1 1}}] [{{gte 1 0}}] [{{gte 0 1}}] [{{gte 0 0}}]`);
 
     assert.equal(find('*').textContent, '[true] [true] [false] [true]', 'value should be "[true] [true] [false] [true]"');
   });
 
   test('decimal values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{gte 19.2 19.2}}] [{{gte 19.2 3.55}}] [{{gte 3.55 19.2}}] [{{gte 3.55 3.55}}]`);
 
     assert.equal(find('*').textContent, '[true] [true] [false] [true]', 'value should be "[true] [true] [false] [true]"');
   });
 
   test('integers in strings 1', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{gte '1' '1' forceNumber=true}}] [{{gte '1' '0' forceNumber=true}}] [{{gte '0' '1' forceNumber=true}}] [{{gte '0' '0' forceNumber=true}}]`
     );
@@ -33,6 +37,7 @@ module('helper:gte', function(hooks) {
   });
 
   test('integers in strings 2', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{gte '102' '102' forceNumber=true}}] [{{gte '102' '98' forceNumber=true}}] [{{gte '98' '102' forceNumber=true}}] [{{gte '98' '98' forceNumber=true}}]`
     );
@@ -41,6 +46,7 @@ module('helper:gte', function(hooks) {
   });
 
   test('decimals in strings', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{gte '19.2' '19.2' forceNumber=true}}] [{{gte '19.2' '3.55' forceNumber=true}}] [{{gte '3.55' '19.2' forceNumber=true}}] [{{gte '3.55' '3.55' forceNumber=true}}]`
     );

--- a/tests/unit/helpers/is-array-test.js
+++ b/tests/unit/helpers/is-array-test.js
@@ -9,6 +9,7 @@ module('helper:is-array', function(hooks) {
   setupRenderingTest(hooks);
 
   test('simple test 1', async function(assert) {
+    assert.expect(3);
     const fakeContextObject = EmberObject.create({
       valueA: null,
       valueB: null

--- a/tests/unit/helpers/is-empty-test.js
+++ b/tests/unit/helpers/is-empty-test.js
@@ -7,6 +7,7 @@ module('helper:is-empty', function(hooks) {
   setupRenderingTest(hooks);
 
   test('undefined/null values', async function(assert) {
+    assert.expect(1);
     this.set('thisIsUndefined', undefined)
     this.set('thisIsNull', null)
     this.set('thisIsNotNull', new Date())
@@ -16,12 +17,14 @@ module('helper:is-empty', function(hooks) {
   });
 
   test('boolean values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{is-empty true}}] [{{is-empty false}}]`);
 
     assert.equal(find('*').textContent, '[false] [false]', 'value should be "[false] [false]"');
   });
 
   test('objects', async function(assert) {
+    assert.expect(1);
     this.set('emptyObject', {})
     this.set('notEmptyObject', { some: 'object' })
     await render(hbs`[{{is-empty emptyObject}}] [{{is-empty notEmptyObject}}]`);
@@ -30,6 +33,7 @@ module('helper:is-empty', function(hooks) {
   });
 
   test('arrays', async function(assert) {
+    assert.expect(1);
     this.set('emptyArray', [])
     this.set('notEmptyArray', [ 'a', 8, {} ])
     await render(hbs`[{{is-empty emptyArray}}] [{{is-empty notEmptyArray}}]`);
@@ -38,6 +42,7 @@ module('helper:is-empty', function(hooks) {
   });
 
   test('strings', async function(assert) {
+    assert.expect(1);
     this.set('emptyString', '')
     this.set('whitespaceString', '   ')
     this.set('notEmptyString', 'full of text')

--- a/tests/unit/helpers/is-equal-test.js
+++ b/tests/unit/helpers/is-equal-test.js
@@ -7,6 +7,7 @@ module('helper:is-equal', function(hooks) {
   setupRenderingTest(hooks);
 
   test('uses isEqual', async function(assert) {
+    assert.expect(1);
     this.set('complex', {
       isEqual(value) {
         return 12 === value;

--- a/tests/unit/helpers/lt-test.js
+++ b/tests/unit/helpers/lt-test.js
@@ -6,26 +6,29 @@ import hbs from 'htmlbars-inline-precompile';
 module('helper:lt', function(hooks) {
   setupRenderingTest(hooks);
 
-  // Replace this with your real tests.
   test('boolean values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{lt true true}}] [{{lt true false}}] [{{lt false true}}] [{{lt false false}}]`);
 
     assert.equal(find('*').textContent, '[false] [false] [true] [false]', 'value should be "[false] [false] [true] [false]"');
   });
 
   test('integer values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{lt 1 1}}] [{{lt 1 0}}] [{{lt 0 1}}] [{{lt 0 0}}]`);
 
     assert.equal(find('*').textContent, '[false] [false] [true] [false]', 'value should be "[false] [false] [true] [false]"');
   });
 
   test('decimal values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{lt 19.2 19.2}}] [{{lt 19.2 3.55}}] [{{lt 3.55 19.2}}] [{{lt 3.55 3.55}}]`);
 
     assert.equal(find('*').textContent, '[false] [false] [true] [false]', 'value should be "[false] [false] [true] [false]"');
   });
 
   test('integers in strings 1', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{lt '1' '1' forceNumber=true}}] [{{lt '1' '0' forceNumber=true}}] [{{lt '0' '1' forceNumber=true}}] [{{lt '0' '0' forceNumber=true}}]`
     );
@@ -34,6 +37,7 @@ module('helper:lt', function(hooks) {
   });
 
   test('integers in strings 2', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{lt '102' '102' forceNumber=true}}] [{{lt '102' '98' forceNumber=true}}] [{{lt '98' '102' forceNumber=true}}] [{{lt '98' '98' forceNumber=true}}]`
     );
@@ -42,6 +46,7 @@ module('helper:lt', function(hooks) {
   });
 
   test('decimals in strings', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{lt '19.2' '19.2' forceNumber=true}}] [{{lt '19.2' '3.55' forceNumber=true}}] [{{lt '3.55' '19.2' forceNumber=true}}] [{{lt '3.55' '3.55' forceNumber=true}}]`
     );

--- a/tests/unit/helpers/lte-test.js
+++ b/tests/unit/helpers/lte-test.js
@@ -6,26 +6,29 @@ import hbs from 'htmlbars-inline-precompile';
 module('helper:lte', function(hooks) {
   setupRenderingTest(hooks);
 
-  // Replace this with your real tests.
   test('boolean values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{lte true true}}] [{{lte true false}}] [{{lte false true}}] [{{lte false false}}]`);
 
     assert.equal(find('*').textContent, '[true] [false] [true] [true]', 'value should be "[false] [false] [true] [true]"');
   });
 
   test('integer values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{lte 1 1}}] [{{lte 1 0}}] [{{lte 0 1}}] [{{lte 0 0}}]`);
 
     assert.equal(find('*').textContent, '[true] [false] [true] [true]', 'value should be "[false] [false] [true] [true]"');
   });
 
   test('decimal values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{lte 19.2 19.2}}] [{{lte 19.2 3.55}}] [{{lte 3.55 19.2}}] [{{lte 3.55 3.55}}]`);
 
     assert.equal(find('*').textContent, '[true] [false] [true] [true]', 'value should be "[false] [false] [true] [true]"');
   });
 
   test('integers in strings 1', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{lte '1' '1' forceNumber=true}}] [{{lte '1' '0' forceNumber=true}}] [{{lte '0' '1' forceNumber=true}}] [{{lte '0' '0' forceNumber=true}}]`
     );
@@ -34,6 +37,7 @@ module('helper:lte', function(hooks) {
   });
 
   test('integers in strings 2', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{lte '102' '102' forceNumber=true}}] [{{lte '102' '98' forceNumber=true}}] [{{lte '98' '102' forceNumber=true}}] [{{lte '98' '98' forceNumber=true}}]`
     );
@@ -42,6 +46,7 @@ module('helper:lte', function(hooks) {
   });
 
   test('decimals in strings', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{lte '19.2' '19.2' forceNumber=true}}] [{{lte '19.2' '3.55' forceNumber=true}}] [{{lte '3.55' '19.2' forceNumber=true}}] [{{lte '3.55' '3.55' forceNumber=true}}]`
     );

--- a/tests/unit/helpers/not-equal-test.js
+++ b/tests/unit/helpers/not-equal-test.js
@@ -9,6 +9,7 @@ module('helper:not-equal', function(hooks) {
   setupRenderingTest(hooks);
 
   test('simple test 1', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{not-eq true true}}] [{{not-eq true false}}] [{{not-eq false true}}] [{{not-eq false false}}]`
     );
@@ -17,6 +18,7 @@ module('helper:not-equal', function(hooks) {
   });
 
   test('simple test 2', async function(assert) {
+    assert.expect(4);
     const fakeContextObject = EmberObject.create({
       valueA: null,
       valueB: null

--- a/tests/unit/helpers/not-test.js
+++ b/tests/unit/helpers/not-test.js
@@ -7,12 +7,14 @@ module('helper:not', function(hooks) {
   setupRenderingTest(hooks);
 
   test('simple test 1', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{not true}}] [{{not false}}] [{{not null}}] [{{not undefined}}] [{{not ''}}] [{{not ' '}}]`);
 
     assert.equal(find('*').textContent, '[false] [true] [true] [true] [true] [false]', 'value should be "[false] [true] [true] [true] [true] [false]"');
   });
 
   test('simple test 2', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{not true false}}] [{{not true false}}] [{{not null null false null}}] [{{not false null ' ' true}}]`
     );

--- a/tests/unit/helpers/or-test.js
+++ b/tests/unit/helpers/or-test.js
@@ -9,12 +9,14 @@ module('helper:or', function(hooks) {
   setupRenderingTest(hooks);
 
   test('simple test 1', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{or true 1 ' ' null undefined}}]`);
 
     assert.equal(find('*').textContent, '[true]', 'value should be "[true]"');
   });
 
   test('simple test 2', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{or null undefined true 1 ' '}}]`);
 
     assert.equal(find('*').textContent, '[true]', 'value should be "[true]"');
@@ -22,6 +24,7 @@ module('helper:or', function(hooks) {
 
 
   test('simple test 3', async function(assert) {
+    assert.expect(1);
     await render(
       hbs`[{{or false}}] [{{or true}}] [{{or 1}}] [{{or ''}}] [{{or false ''}}] [{{or true ''}}] [{{or '' true}}]`
     );
@@ -30,6 +33,7 @@ module('helper:or', function(hooks) {
   });
 
   test('simple test 4', async function(assert) {
+    assert.expect(5);
     const fakeContextObject = EmberObject.create({
       valueA: null,
       valueB: null
@@ -54,6 +58,5 @@ module('helper:or', function(hooks) {
 
     run(fakeContextObject, 'set', 'valueB', 'yellow');
     assert.equal(find('*').textContent, '[ ] [yellow] [yellow] [ ]', 'value should be "[ ] [yellow] [yellow] [ ]"');
-
   });
 });

--- a/tests/unit/helpers/or-with-not-eq-test.js
+++ b/tests/unit/helpers/or-with-not-eq-test.js
@@ -7,30 +7,35 @@ module('helper:or', function(hooks) {
   setupRenderingTest(hooks);
 
   test('simple test 1', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{or (not-eq true false) (not-eq true false)}}]`);
 
     assert.equal(find('*').textContent, '[true]', 'value should be "[true]"');
   });
 
   test('simple test 2', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{or (not-eq true true) (not-eq false false)}}]`);
 
     assert.equal(find('*').textContent, '[false]', 'value should be "[true]"');
   });
 
   test('simple test 3', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{or (not-eq true true) (not-eq true false)}}]`);
 
     assert.equal(find('*').textContent, '[true]', 'value should be "[true]"');
   });
 
   test('simple test 4', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{or (not-eq true false) (not-eq false false)}}]`);
 
     assert.equal(find('*').textContent, '[true]', 'value should be "[true]"');
   });
 
   test('simple test 5', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{#if (or (not-eq true false) (not-eq false false))}}true{{else}}false{{/if}}]`);
 
     assert.equal(find('*').textContent, '[true]', 'value should be "[true]"');

--- a/tests/unit/helpers/xor-test.js
+++ b/tests/unit/helpers/xor-test.js
@@ -7,6 +7,7 @@ module('helper:xor', function(hooks) {
   setupRenderingTest(hooks);
 
   test('boolean values', async function(assert) {
+    assert.expect(1);
     await render(hbs`[{{xor true true}}] [{{xor true false}}] [{{xor false true}}] [{{xor false false}}]`);
 
     assert.equal(find('*').textContent, '[false] [true] [true] [false]', 'value should be "[false] [true] [true] [false]"');


### PR DESCRIPTION
This PR adds [expect](https://api.qunitjs.com/assert/expect) to each test.

> To ensure that an explicit number of assertions are run within any test, use assert.expect( number ) to register an expected count. If the number of assertions run does not match the expected count, the test will fail.