### PR TITLE
fix: proper named export

### DIFF
--- a/app/helpers/not-eq.js
+++ b/app/helpers/not-eq.js
@@ -1,1 +1,1 @@
-export { default, notEq } from 'ember-truth-helpers/helpers/not-equal';
+export { default, notEqualHelper } from 'ember-truth-helpers/helpers/not-equal';


### PR DESCRIPTION
https://github.com/jmurphyau/ember-truth-helpers/blob/master/addon/helpers/not-equal.js

exported as `notEqualHelper`