### PR TITLE
Fix for #109: not-eq has unknown reexport

### DIFF
--- a/addon/helpers/not-equal.js
+++ b/addon/helpers/not-equal.js
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 
-export function notEqualHelper(params) {
+export function notEq(params) {
   return params[0] !== params[1];
 }
 
-export default helper(notEqualHelper);
+export default helper(notEq);


### PR DESCRIPTION
Fixes error exposed by webpack / embroider:
"export 'notEq' was not found in '../node_modules/ember-truth-helpers/helpers/not-equal'