### PR TITLE
Export `eq` and `not-eq` directly from /addon

### DIFF
--- a/addon/helpers/eq.js
+++ b/addon/helpers/eq.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-truth-helpers/helpers/equal';

--- a/addon/helpers/not-eq.js
+++ b/addon/helpers/not-eq.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-truth-helpers/helpers/not-equal';

--- a/app/helpers/eq.js
+++ b/app/helpers/eq.js
@@ -1,1 +1,1 @@
-export { default, equal } from 'ember-truth-helpers/helpers/equal';
+export { default, equal } from 'ember-truth-helpers/helpers/eq';

--- a/app/helpers/not-eq.js
+++ b/app/helpers/not-eq.js
@@ -1,1 +1,1 @@
-export { default, notEqualHelper } from 'ember-truth-helpers/helpers/not-equal';
+export { default, notEqualHelper } from 'ember-truth-helpers/helpers/not-eq';


### PR DESCRIPTION
A certain million+ line Ember app would love to use this addon, but because it uses the [batman syntax addon](https://github.com/rwjblue/ember-holy-futuristic-template-namespacing-batman), the differently named exports from `app` aren't found. So while it's possible to do `ember-truth-helpers$equal` that doesn't match up with this addon's docs.

Another option is to rename `/addon/helpers/equal.js ---> /addon/helpers/eq.js` and `/addon/helpers/not-equal.js ---> /addon/helpers/not-eq.js` and bump the major 🤷 