### PR TITLE
Add new workflow to provide release branches

### DIFF
--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -1,0 +1,29 @@
+# .github/workflows/push-dist.yml
+
+name: Push dist
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  push-dist:
+    name: Push dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v3
+        with:
+          cache: 'pnpm'
+      - name: Install Dependencies
+        run: pnpm install
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
+        with:
+          branch: ${{ github.head_ref || github.ref_name }}-dist
+          working-directory: packages/ember-truth-helpers
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
this PR adds https://github.com/kategengler/put-built-npm-package-contents-on-branch/ to allow test latest changes in v2 add-on.

this was easily done for v1 addons by using GitHub urls in package.json which is not possible for monorepos.