### PR TITLE
(fix): infer return type in "or" and "and" helpers

### DIFF
--- a/packages/ember-truth-helpers/src/helpers/or.ts
+++ b/packages/ember-truth-helpers/src/helpers/or.ts
@@ -2,18 +2,30 @@ import { helper } from '@ember/component/helper';
 import truthConvert from '../utils/truth-convert.ts';
 import type { MaybeTruth } from '../utils/truth-convert.ts';
 
-export interface OrSignature {
-  Args: {
-    Positional: MaybeTruth[];
-  };
-  Return: boolean;
-}
-
-export default helper<OrSignature>((params) => {
+export default helper(<T extends MaybeTruth[]>(params: [...T]) => {
   for (let i = 0, len = params.length; i < len; i++) {
     if (truthConvert(params[i]) === true) {
-      return params[i] as boolean;
+      return params[i] as FirstNonFalsy<T>;
     }
   }
-  return params[params.length - 1] as boolean;
+
+  return params[params.length - 1] as Last<T>;
 });
+
+type FirstNonFalsy<T extends any[]> = T extends [infer K]
+  ? K
+  : T extends [infer A, ...infer R]
+  ? Truthy<A> extends true
+    ? A
+    : FirstNonFalsy<R>
+  : never;
+
+type Last<T extends any[]> = T extends [infer K]
+  ? K
+  : T extends [...infer Q, infer L]
+  ? L
+  : never;
+
+type Truthy<T> = T extends Falsy ? false : true;
+
+type Falsy = false | 0 | '' | null | undefined | { isTruthy: false } | [];

--- a/packages/modern-test-app/app/components/and-or-type-checking.hbs
+++ b/packages/modern-test-app/app/components/and-or-type-checking.hbs
@@ -1,0 +1,4 @@
+<div>
+  {{log @andArg}}
+  {{log @orArg}}
+</div>

--- a/packages/modern-test-app/app/components/and-or-type-checking.ts
+++ b/packages/modern-test-app/app/components/and-or-type-checking.ts
@@ -1,0 +1,19 @@
+import templateOnly from '@ember/component/template-only';
+
+interface Signature {
+  Element: HTMLDivElement;
+  Args: {
+    andArg: object | boolean;
+    orArg: object | boolean;
+  };
+}
+
+const AndOrTypeChecking = templateOnly<Signature>();
+
+export default AndOrTypeChecking;
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    AndOrTypeChecking: typeof AndOrTypeChecking;
+  }
+}

--- a/packages/modern-test-app/app/templates/helpers.hbs
+++ b/packages/modern-test-app/app/templates/helpers.hbs
@@ -10,3 +10,8 @@
 {{not true}}
 {{or true false}}
 {{xor true false}}
+
+<AndOrTypeChecking
+  @andArg={{or (hash) (array)}}
+  @orArg={{and (hash) (array)}}
+/>


### PR DESCRIPTION
with `v4.0.0-beta.0`, return type for `and` and `or` is `boolean` which does not match the semantics of the helper itself.

see https://github.com/jmurphyau/ember-truth-helpers/blob/v4.0.0-beta.0/packages/ember-truth-helpers/src/helpers/or.ts#L9

This PR tries to infer the return type from the arguments, kinda similar to what was previously done in https://github.com/Gavant/glint-template-types/blob/v0.3.5/types/ember-truth-helpers/or.d.ts without limiting to 5 arguments.

This still does not work as intended, so more work needed.