### PR TITLE
Drop old ember

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,6 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-3.28
-          - ember-lts-4.4
           - ember-lts-4.8
           - ember-lts-4.12
           - ember-release

--- a/packages/modern-test-app/config/ember-try.js
+++ b/packages/modern-test-app/config/ember-try.js
@@ -8,22 +8,6 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-4.4',
-        npm: {
-          devDependencies: {
-            'ember-source': '~4.4.0',
-          },
-        },
-      },
-      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/packages/test-app/config/ember-try.js
+++ b/packages/test-app/config/ember-try.js
@@ -8,24 +8,6 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
-        name: 'ember-lts-3.28',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.28.0',
-            'ember-resolver': '^8.1.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-4.4',
-        npm: {
-          devDependencies: {
-            'ember-source': '~4.4.0',
-            'ember-resolver': '^8.1.0',
-          },
-        },
-      },
-      {
         name: 'ember-lts-4.8',
         npm: {
           devDependencies: {


### PR DESCRIPTION
In order to get https://github.com/jmurphyau/ember-truth-helpers/pull/188 green, 
we need to drop ember < 4.5.

An alternative could be to add the plain functions polyfill, which is inert after 4.5