### PR TITLE
Failing test for and / or types

### DIFF
--- a/packages/modern-test-app/app/components/and-or-type-checking.ts
+++ b/packages/modern-test-app/app/components/and-or-type-checking.ts
@@ -5,6 +5,8 @@ interface Signature {
   Args: {
     andArg: object | boolean;
     orArg: object | boolean;
+    andFallbackArg: string;
+    orFallbackArg: string;
   };
 }
 

--- a/packages/modern-test-app/app/templates/helpers.hbs
+++ b/packages/modern-test-app/app/templates/helpers.hbs
@@ -12,6 +12,8 @@
 {{xor true false}}
 
 <AndOrTypeChecking
-  @andArg={{or (hash) (array)}}
-  @orArg={{and (hash) (array)}}
+  @andArg={{and (hash) (array)}}
+  @orArg={{or (hash) (array)}}
+  @andFallbackArg={{and true "string"}}
+  @orFallbackArg={{or false "string"}}
 />

--- a/packages/modern-test-app/app/templates/helpers.hbs
+++ b/packages/modern-test-app/app/templates/helpers.hbs
@@ -14,6 +14,8 @@
 <AndOrTypeChecking
   @andArg={{and (hash) (array)}}
   @orArg={{or (hash) (array)}}
+  {{!-- and returns the last truthy item --}}
   @andFallbackArg={{and true "string"}}
-  @orFallbackArg={{or false "string"}}
+  {{!-- or returns the first truthy item --}}
+  @orFallbackArg={{or undefined "string"}}
 />


### PR DESCRIPTION
Just wanted to create this failing types test, as the v4 release didn't quite nail the and / or helper types

This might be partially resolved by https://github.com/jmurphyau/ember-truth-helpers/pull/191 ? But I am not sure.

We probably want some return types like this (examples adapted from this example https://github.com/microsoft/TypeScript/issues/31579 )
```ts
type Or<A extends boolean, B extends boolean> = A extends true
    ? A // A was truthy, returns itself
    : B extends true
        ? B // B was truthy, returns itself
        : B // last item in logical OR returns itself even if falsey
// for multiple args
type Or3<A extends boolean, B extends boolean, C extends boolean> = Or<A, Or<B, C>>
```