### PR TITLE
Further type improvements for `or` helper

### DIFF
--- a/packages/ember-truth-helpers/src/helpers/or.ts
+++ b/packages/ember-truth-helpers/src/helpers/or.ts
@@ -1,4 +1,5 @@
 import truthConvert, {
+  Falsy,
   MaybeTruthy,
   TruthConvert,
 } from '../utils/truth-convert.ts';
@@ -11,7 +12,7 @@ type FirstTruthy<T> = T extends [infer Item]
     ? Head
     : TruthConvert<Head> extends false
     ? FirstTruthy<Tail>
-    : NonNullable<Head> | FirstTruthy<Tail>
+    : Exclude<Head, Falsy> | FirstTruthy<Tail>
   : undefined;
 
 interface OrSignature<T extends MaybeTruthy[]> {

--- a/packages/ember-truth-helpers/src/utils/truth-convert.ts
+++ b/packages/ember-truth-helpers/src/utils/truth-convert.ts
@@ -1,9 +1,22 @@
 import { isArray } from '@ember/array';
 
+export type Falsy =
+  | { isTruthy: false }
+  | undefined
+  | null
+  | false
+  | 0
+  | -0
+  | 0n
+  | ''
+  | never[];
+
 type ConvertTruthyObject<T> = T extends { isTruthy: infer U } ? U : T;
 
 // We check here in the order of the following function to maintain parity
 // Note that this will not handle EmberArray correctly.
+// We don't use Falsy since we want to be able to more definitively determine
+// truthy results.
 type _TruthConvert<T> = T extends { isTruthy: true }
   ? true
   : T extends { isTruthy: false }

--- a/packages/ember-truth-helpers/src/utils/truth-convert.ts
+++ b/packages/ember-truth-helpers/src/utils/truth-convert.ts
@@ -11,13 +11,11 @@ export type Falsy =
   | ''
   | never[];
 
-type ConvertTruthyObject<T> = T extends { isTruthy: infer U } ? U : T;
-
 // We check here in the order of the following function to maintain parity
 // Note that this will not handle EmberArray correctly.
 // We don't use Falsy since we want to be able to more definitively determine
 // truthy results.
-type _TruthConvert<T> = T extends { isTruthy: true }
+export type TruthConvert<T> = T extends { isTruthy: true }
   ? true
   : T extends { isTruthy: false }
   ? false
@@ -30,14 +28,20 @@ type _TruthConvert<T> = T extends { isTruthy: true }
   : T extends number
   ? T extends 0 | -0
     ? false
+    : number extends T
+    ? boolean
     : true
   : T extends bigint
   ? T extends 0n
     ? false
+    : bigint extends T
+    ? boolean
     : true
   : T extends string
   ? T extends ''
     ? false
+    : string extends T
+    ? boolean
     : true
   : T extends never[]
   ? false
@@ -46,7 +50,6 @@ type _TruthConvert<T> = T extends { isTruthy: true }
   : T extends object
   ? true
   : boolean;
-export type TruthConvert<T> = _TruthConvert<ConvertTruthyObject<T>>;
 
 export type MaybeTruthy =
   | { isTruthy: boolean }

--- a/packages/ember-truth-helpers/type-tests/helpers/or.test.ts
+++ b/packages/ember-truth-helpers/type-tests/helpers/or.test.ts
@@ -29,3 +29,11 @@ expectTypeOf(computeOr(foo, 1)).toEqualTypeOf(foo);
 
 let maybeString: string | undefined;
 expectTypeOf(computeOr(maybeString, 'foo')).toEqualTypeOf<string>();
+
+const numberOrFalse = 1 as number | false;
+expectTypeOf(computeOr(numberOrFalse, 'foo')).toEqualTypeOf<number | 'foo'>();
+
+const numberOrNotTruthy = 1 as number | { isTruthy: false };
+expectTypeOf(computeOr(numberOrNotTruthy, 'foo')).toEqualTypeOf<
+  number | 'foo'
+>();

--- a/packages/ember-truth-helpers/type-tests/utils/truth-convert.test.ts
+++ b/packages/ember-truth-helpers/type-tests/utils/truth-convert.test.ts
@@ -7,14 +7,19 @@ expectTypeOf<TruthConvert<undefined>>().toEqualTypeOf<false>();
 
 expectTypeOf<TruthConvert<true>>().toEqualTypeOf<true>();
 expectTypeOf<TruthConvert<false>>().toEqualTypeOf<false>();
+expectTypeOf<TruthConvert<boolean>>().toEqualTypeOf<boolean>();
 
 expectTypeOf<TruthConvert<0>>().toEqualTypeOf<false>();
 expectTypeOf<TruthConvert<-0>>().toEqualTypeOf<false>();
-expectTypeOf<TruthConvert<0n>>().toEqualTypeOf<false>();
 expectTypeOf<TruthConvert<1>>().toEqualTypeOf<true>();
+expectTypeOf<TruthConvert<number>>().toEqualTypeOf<boolean>();
+expectTypeOf<TruthConvert<0n>>().toEqualTypeOf<false>();
+expectTypeOf<TruthConvert<1n>>().toEqualTypeOf<true>();
+expectTypeOf<TruthConvert<bigint>>().toEqualTypeOf<boolean>();
 
 expectTypeOf<TruthConvert<''>>().toEqualTypeOf<false>();
 expectTypeOf<TruthConvert<'A String'>>().toEqualTypeOf<true>();
+expectTypeOf<TruthConvert<string>>().toEqualTypeOf<boolean>();
 
 expectTypeOf<TruthConvert<{ foo: 1; isTruthy: true }>>().toEqualTypeOf<true>();
 expectTypeOf<
@@ -22,6 +27,7 @@ expectTypeOf<
 >().toEqualTypeOf<false>();
 // isTruthy isn't a boolean but we still have a real object so it's truthy
 expectTypeOf<TruthConvert<{ foo: 1; isTruthy: 1 }>>().toEqualTypeOf<true>();
+expectTypeOf<TruthConvert<{ isTruthy: boolean }>>().toEqualTypeOf<boolean>();
 
 expectTypeOf<TruthConvert<never[]>>().toEqualTypeOf<false>();
 expectTypeOf<TruthConvert<string[]>>().toEqualTypeOf<boolean>();
@@ -29,6 +35,9 @@ expectTypeOf<TruthConvert<string[]>>().toEqualTypeOf<boolean>();
 expectTypeOf<
   TruthConvert<never[] & { isTruthy: true }>
 >().toEqualTypeOf<true>();
+
+expectTypeOf<TruthConvert<1 | false>>().toEqualTypeOf<boolean>();
+expectTypeOf<TruthConvert<0 | false>>().toEqualTypeOf<false>();
 
 expectTypeOf(truthConvert(null)).toEqualTypeOf<false>();
 expectTypeOf(truthConvert(undefined)).toEqualTypeOf<false>();


### PR DESCRIPTION
* Improves the `or` helper types to correctly handle removing falsy types.
* Corrects TruthConvert types to better handle non-literal types (e.g. number vs 1).