### PR TITLE
Use put-built-npm-package-contents-on-branch@v2.0.0

### DIFF
--- a/.github/workflows/push-dist.yml
+++ b/.github/workflows/push-dist.yml
@@ -25,7 +25,7 @@ jobs:
           cache: pnpm
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
-      - uses: kategengler/put-built-npm-package-contents-on-branch@v1.0.0
+      - uses: kategengler/put-built-npm-package-contents-on-branch@v2.0.0
         with:
           branch: ${{ github.head_ref || github.ref_name }}-dist
           working-directory: packages/ember-truth-helpers


### PR DESCRIPTION
skip running `prepack` command if installed via `master-dist` branch
See https://github.com/kategengler/put-built-npm-package-contents-on-branch/pull/2 for details