### PR TITLE
Remove unnecessary `template-registry.js` export in `rollup.config.mjs`

### DIFF
--- a/packages/ember-truth-helpers/rollup.config.mjs
+++ b/packages/ember-truth-helpers/rollup.config.mjs
@@ -19,7 +19,6 @@ export default {
     // addon. Anything not listed here may get optimized away.
     addon.publicEntrypoints([
       'index.js',
-      'template-registry.js',
       'helpers/**/*.js',
       'utils/**/*.js',
     ]),


### PR DESCRIPTION
This is fixing a warning while rollup & also a unnecessary file on npm

```
../ember-truth-helpers prepare: [js] (!) Generated an empty chunk
../ember-truth-helpers prepare: [js] "template-registry"
```

![grafik](https://github.com/jmurphyau/ember-truth-helpers/assets/19845290/3a5cd586-7a2a-4bc8-9926-75ba7af9277f)
